### PR TITLE
NB-9161 Improve node integration test Docker helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,85 @@
 # node-it-docker
 
-**Node Docker IT DB Launcher**
+Node Docker IT DB Launcher for NurseBuddy integration tests.
 
-This tool provides a way to spin up and manage MySQL containers for integration testing purposes using Docker and Node.js.
+This helper starts and manages the MySQL integration-test database container
+used by Node services. It supports the legacy fixed-port mode and an opt-in
+dynamic mode for parallel and CI-safe test runs.
 
-## 🚀 Features
-
-- Spin up MySQL Docker containers for integration testing
-- Built-in support for container management via Docker API
-- Structured logging using Pino
-
-## 📦 Installation
+## Install
 
 ```bash
-npm install
+yarn install
+```
+
+## Usage
+
+```js
+const { NodeItDocker } = require('node-it-docker');
+
+const nodeItDocker = NodeItDocker({
+  dynamicPort: true,
+});
+
+const db = await nodeItDocker.start();
+
+// Configure the service under test with db.host, db.port, db.user,
+// db.password, and db.database.
+
+await nodeItDocker.stop();
+```
+
+## Options
+
+| Option | Default | Notes |
+|---|---|---|
+| `itImageName` | `989173062527.dkr.ecr.eu-west-1.amazonaws.com/it-mysql-v2` | Docker image to run. |
+| `itContainerName` | `node-it-container-qwerty12345` | Legacy default unless `dynamicPort` or `useDynamicDefaults` is enabled. |
+| `externalPort` | `3806` | Legacy host port. Use `0` for a dynamic Docker-assigned host port. |
+| `dynamicPort` | `false` | Enables Docker-assigned host port and unique default container/network names. |
+| `useDynamicDefaults` | `false` | Enables unique default container/network names without forcing `externalPort` when explicitly provided. |
+| `containerNetworkName` | `node-it-test-net` | Legacy default unless dynamic defaults are enabled. |
+| `dataDir` | `/var/lib/mysql` | MySQL data tmpfs mount path. |
+| `currentContainerId` | `null` | Connects the current container to the DB network; also reads `IT_CONTAINER`. |
+| `verifyDbConnection` | `true` | Verifies the `integration_test_flag` table before returning DB params. |
+| `dbUsername` | `ituser` | MySQL username. |
+| `dbPassword` | `ituser` | MySQL password. |
+| `dbName` | `nursebuddy` | MySQL database name. |
+
+## Environment Overrides
+
+Image override precedence:
+
+1. `IT_IMAGE_NAME`
+2. `IT_MYSQL_IMAGE`
+3. `itImageName` option
+4. built-in `it-mysql-v2` image
+
+`IT_CONTAINER` overrides `currentContainerId`.
+
+`IT_IMAGE_NAME` is the legacy env var and keeps precedence for compatibility.
+`IT_MYSQL_IMAGE` exists so GitHub workflows can pass the resolved/pulled test DB
+image name without changing existing service code that still uses
+`IT_IMAGE_NAME`.
+
+## Compatibility Notes
+
+Version `1.2.0` keeps the legacy no-option defaults:
+
+- container name: `node-it-container-qwerty12345`
+- network name: `node-it-test-net`
+- host port: `3806`
+- returned DB fields: `host`, `port`, `user`, `password`, `database`
+
+Services updated under NB-9161 should opt in to dynamic behavior with
+`dynamicPort: true`. A future major version can make dynamic behavior the
+default after all consumers have moved away from the legacy fixed port.
+
+## Testing
+
+```bash
+npm test
+```
+
+The test suite uses mocked Docker and MySQL clients. It does not start a real
+Docker container.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ const db = await nodeItDocker.start();
 
 // Configure the service under test with db.host, db.port, db.user,
 // db.password, and db.database.
+//
+// DB-heavy suites can restore the baseline database without restarting the
+// Docker container when the IT DB image supports it:
+// await nodeItDocker.resetDatabase();
 
 await nodeItDocker.stop();
 ```
@@ -75,6 +79,11 @@ Services updated under NB-9161 should opt in to dynamic behavior with
 `dynamicPort: true`. A future major version can make dynamic behavior the
 default after all consumers have moved away from the legacy fixed port.
 
+`resetDatabase()` is an opt-in faster reset for suites that need a full
+database baseline between groups of tests. It calls the reset script baked into
+newer IT DB images and falls back to the legacy container `restart()` path when
+running against an older image.
+
 ## Testing
 
 ```bash
@@ -92,7 +101,7 @@ npm run smoke:docker
 ```
 
 The smoke starts `it-mysql-v2` with `dynamicPort: true`, verifies MySQL
-connectivity, exercises `restart()`, and then stops the container. It requires
-Docker access and access to the configured integration-test DB image. Use
-`IT_IMAGE_NAME` or `IT_MYSQL_IMAGE` to point at a locally available image if
-needed.
+connectivity, exercises `resetDatabase()` and `restart()`, and then stops the
+container. It requires Docker access and access to the configured
+integration-test DB image. Use `IT_IMAGE_NAME` or `IT_MYSQL_IMAGE` to point at a
+locally available image if needed.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,16 @@ npm test
 
 The test suite uses mocked Docker and MySQL clients. It does not start a real
 Docker container.
+
+Run the optional Docker smoke before rolling a new helper version into service
+pilot branches:
+
+```bash
+npm run smoke:docker
+```
+
+The smoke starts `it-mysql-v2` with `dynamicPort: true`, verifies MySQL
+connectivity, exercises `restart()`, and then stops the container. It requires
+Docker access and access to the configured integration-test DB image. Use
+`IT_IMAGE_NAME` or `IT_MYSQL_IMAGE` to point at a locally available image if
+needed.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ dynamic mode for parallel and CI-safe test runs.
 ## Install
 
 ```bash
-yarn install
+npm install https://github.com/NurseBuddy/node-it-docker/archive/v1.2.0.tar.gz
 ```
 
 ## Usage

--- a/node-it-docker.js
+++ b/node-it-docker.js
@@ -300,7 +300,8 @@ function createNodeItDocker(dockerClient = docker, mysqlClient = mysql, logger =
         if (await verifyDatabaseConnection(verifyDbConnection, mysqlClient, resolvedExternalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, stop, logger, sleepFn)) {
           return getDbConnectionParameters();
         }
-        return null;
+        logger.warn('Restart verification failed, starting new container.');
+        return start();
       } catch (err) {
         logger.warn('Restart failed, starting new container.', err);
         await stop();

--- a/node-it-docker.js
+++ b/node-it-docker.js
@@ -41,10 +41,23 @@ function createLabels(runId) {
   };
 }
 
+function isAlreadyConnectedNetworkError(err) {
+  const message = err && err.message ? err.message : `${err}`;
+  return /already connected|endpoint .*already exists|endpoint with name .* already exists/i.test(message);
+}
+
 async function connectRunningContainerToNetwork(currentContainerId, network, logger) {
   if (currentContainerId) {
     logger.info(`Connecting the current container ('${currentContainerId}') to the IT DB network.`);
-    await network.connect({ Container: currentContainerId });
+    try {
+      await network.connect({ Container: currentContainerId });
+    } catch (err) {
+      if (isAlreadyConnectedNetworkError(err)) {
+        logger.info(`Current container ('${currentContainerId}') is already connected to the IT DB network.`);
+        return;
+      }
+      throw err;
+    }
   }
 }
 
@@ -205,7 +218,11 @@ function createNodeItDocker(dockerClient = docker, mysqlClient = mysql, logger =
       try {
         const network = dockerClient.getNetwork(containerNetworkName);
         if (currentContainerId) {
-          await disconnectRunningContainerFromNetwork(currentContainerId, network, logger);
+          try {
+            await disconnectRunningContainerFromNetwork(currentContainerId, network, logger);
+          } catch (err) {
+            logger.warn('Failed to disconnect current container from network:', err);
+          }
         }
         await network.remove({ force: true });
         logger.info('Container stopped.');

--- a/node-it-docker.js
+++ b/node-it-docker.js
@@ -188,12 +188,18 @@ function createNodeItDocker(dockerClient = docker, mysqlClient = mysql, logger =
     }
 
     async function stop() {
+      const container = dockerClient.getContainer(itContainerName);
+
       try {
-        const container = dockerClient.getContainer(itContainerName);
         await container.stop();
+      } catch (err) {
+        logger.warn('Failed to stop container:', err);
+      }
+
+      try {
         await container.remove({ force: true });
       } catch (err) {
-        logger.warn('Failed to stop or remove container:', err);
+        logger.warn('Failed to remove container:', err);
       }
 
       try {
@@ -211,45 +217,46 @@ function createNodeItDocker(dockerClient = docker, mysqlClient = mysql, logger =
     async function start() {
       let container;
       let inspected;
-      const network = await getOrCreateNetwork(dockerClient, containerNetworkName, labels, logger);
 
       try {
+        const network = await getOrCreateNetwork(dockerClient, containerNetworkName, labels, logger);
         container = dockerClient.getContainer(itContainerName);
-        inspected = await container.inspect();
-      } catch {
-        logger.info('Creating container');
-        container = await dockerClient.createContainer({
-          Image: itImageName,
-          name: itContainerName,
-          Labels: labels,
-          ExposedPorts: {
-            [`${MYSQL_DEFAULT_PORT}/tcp`]: {},
-          },
-          HostConfig: {
-            PortBindings: {
-              [`${MYSQL_DEFAULT_PORT}/tcp`]: [{
-                HostIP: '0.0.0.0',
-                HostPort: isDynamicHostPort(configuredExternalPort) ? '' : `${configuredExternalPort}`,
-              }],
+
+        try {
+          inspected = await container.inspect();
+        } catch {
+          logger.info('Creating container');
+          container = await dockerClient.createContainer({
+            Image: itImageName,
+            name: itContainerName,
+            Labels: labels,
+            ExposedPorts: {
+              [`${MYSQL_DEFAULT_PORT}/tcp`]: {},
             },
-            Tmpfs: {
-              [dataDir]: 'rw,noexec,nosuid,size=600m',
-              '/tmp': 'rw,noexec,nosuid,size=50m',
-            },
-          },
-          NetworkingConfig: {
-            EndpointsConfig: {
-              [containerNetworkName]: {
-                Aliases: [itContainerName],
+            HostConfig: {
+              PortBindings: {
+                [`${MYSQL_DEFAULT_PORT}/tcp`]: [{
+                  HostIP: '0.0.0.0',
+                  HostPort: isDynamicHostPort(configuredExternalPort) ? '' : `${configuredExternalPort}`,
+                }],
+              },
+              Tmpfs: {
+                [dataDir]: 'rw,noexec,nosuid,size=600m',
+                '/tmp': 'rw,noexec,nosuid,size=50m',
               },
             },
-          },
-        });
-        container = dockerClient.getContainer(container.id);
-        logger.info(`Container '${container.id}' created.`);
-      }
+            NetworkingConfig: {
+              EndpointsConfig: {
+                [containerNetworkName]: {
+                  Aliases: [itContainerName],
+                },
+              },
+            },
+          });
+          container = dockerClient.getContainer(container.id);
+          logger.info(`Container '${container.id}' created.`);
+        }
 
-      try {
         if (!inspected || !inspected.State || !inspected.State.Running) {
           await container.start();
         }

--- a/node-it-docker.js
+++ b/node-it-docker.js
@@ -18,6 +18,7 @@ const DEFAULT_IT_CONTAINER_NAME = 'node-it-container-qwerty12345';
 const DEFAULT_CONTAINER_NETWORK_NAME = 'node-it-test-net';
 const DEFAULT_EXTERNAL_PORT = 3806;
 const RESET_SCRIPT_PATH = '/usr/local/bin/reset-nursebuddy-db';
+const VERIFY_DB_CONNECTION_MAX_ATTEMPTS = 120;
 
 async function sleep(timeMs) {
   return new Promise(resolve => setTimeout(resolve, timeMs));
@@ -121,16 +122,25 @@ async function connect(mysqlClient, externalPort, currentContainerId, itContaine
   });
 }
 
+function getVerifySleepMs(attempt) {
+  if (attempt < 10) {
+    return 100;
+  }
+  if (attempt < 30) {
+    return 250;
+  }
+  return 500;
+}
+
 async function verifyDatabaseConnection(verifyDbConnection, mysqlClient, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, stopFn, logger, sleepFn) {
   let lastError;
-  let waitPeriod = 500;
   const start = Date.now();
 
   if (!verifyDbConnection) {
     return true;
   }
 
-  for (let i = 0; i < 10; i++) {
+  for (let attempt = 0; attempt < VERIFY_DB_CONNECTION_MAX_ATTEMPTS; attempt++) {
     try {
       if (await connect(mysqlClient, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName)) {
         logger.info(`DB Connection verified in : ${Date.now() - start} ms.`);
@@ -139,8 +149,9 @@ async function verifyDatabaseConnection(verifyDbConnection, mysqlClient, externa
     } catch (err) {
       lastError = err;
     }
-    await sleepFn(waitPeriod);
-    waitPeriod += Math.round(waitPeriod / 2);
+    if (attempt < VERIFY_DB_CONNECTION_MAX_ATTEMPTS - 1) {
+      await sleepFn(getVerifySleepMs(attempt));
+    }
   }
 
   logger.warn({ msg: 'DB connection failed:', error: lastError });

--- a/node-it-docker.js
+++ b/node-it-docker.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Writable } = require('stream');
 const Docker = require('dockerode');
 const pino = require('pino');
 const mysql = require('mysql');
@@ -16,6 +17,7 @@ const DEFAULT_IT_IMAGE_NAME = '989173062527.dkr.ecr.eu-west-1.amazonaws.com/it-m
 const DEFAULT_IT_CONTAINER_NAME = 'node-it-container-qwerty12345';
 const DEFAULT_CONTAINER_NETWORK_NAME = 'node-it-test-net';
 const DEFAULT_EXTERNAL_PORT = 3806;
+const RESET_SCRIPT_PATH = '/usr/local/bin/reset-nursebuddy-db';
 
 async function sleep(timeMs) {
   return new Promise(resolve => setTimeout(resolve, timeMs));
@@ -168,6 +170,69 @@ async function resolveExternalPort(container, externalPort, currentContainerId) 
   return bindings[0].HostPort;
 }
 
+function collectExecOutput(dockerClient, stream) {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+
+    const stdoutStream = new Writable({
+      write(chunk, encoding, callback) {
+        stdout += chunk.toString();
+        callback();
+      },
+    });
+    const stderrStream = new Writable({
+      write(chunk, encoding, callback) {
+        stderr += chunk.toString();
+        callback();
+      },
+    });
+
+    stream.on('end', () => resolve({ stdout, stderr }));
+    stream.on('error', reject);
+
+    if (dockerClient.modem && typeof dockerClient.modem.demuxStream === 'function') {
+      dockerClient.modem.demuxStream(stream, stdoutStream, stderrStream);
+      return;
+    }
+
+    stream.on('data', chunk => {
+      stdout += chunk.toString();
+    });
+  });
+}
+
+async function execInContainer(dockerClient, container, cmd) {
+  const exec = await container.exec({
+    Cmd: cmd,
+    AttachStdout: true,
+    AttachStderr: true,
+  });
+
+  const stream = await exec.start({ hijack: true, stdin: false });
+  const output = await collectExecOutput(dockerClient, stream);
+  const inspected = await exec.inspect();
+
+  if (inspected.ExitCode !== 0) {
+    const err = new Error(`Container command failed with exit code ${inspected.ExitCode}: ${cmd.join(' ')}`);
+    err.exitCode = inspected.ExitCode;
+    err.stdout = output.stdout;
+    err.stderr = output.stderr;
+    throw err;
+  }
+
+  return output;
+}
+
+function isResetScriptUnavailable(err) {
+  const output = `${err.stdout || ''}\n${err.stderr || ''}\n${err.message || ''}`;
+
+  return err.exitCode === 66
+    || err.exitCode === 126
+    || err.exitCode === 127
+    || /Missing \/baseline\.sql|No such file|not found|executable file not found/i.test(output);
+}
+
 function createNodeItDocker(dockerClient = docker, mysqlClient = mysql, logger = log, sleepFn = sleep) {
   return function NodeItDocker(options = {}) {
     const runId = createRunId();
@@ -309,10 +374,36 @@ function createNodeItDocker(dockerClient = docker, mysqlClient = mysql, logger =
       }
     }
 
+    async function resetDatabase() {
+      if (dbName !== 'nursebuddy') {
+        logger.warn(`SQL reset only supports the nursebuddy database, falling back to container restart for '${dbName}'.`);
+        return restart();
+      }
+
+      try {
+        const container = dockerClient.getContainer(itContainerName);
+        await execInContainer(dockerClient, container, [RESET_SCRIPT_PATH, dbName]);
+        resolvedExternalPort = await resolveExternalPort(container, configuredExternalPort, currentContainerId);
+        if (await verifyDatabaseConnection(verifyDbConnection, mysqlClient, resolvedExternalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, stop, logger, sleepFn)) {
+          return getDbConnectionParameters();
+        }
+        logger.warn('SQL reset verification failed, falling back to container restart.');
+        return restart();
+      } catch (err) {
+        if (isResetScriptUnavailable(err)) {
+          logger.warn('SQL reset script is unavailable in the IT DB image, falling back to container restart.', err);
+        } else {
+          logger.warn('SQL reset failed, falling back to container restart.', err);
+        }
+        return restart();
+      }
+    }
+
     return {
       stop,
       start,
       restart,
+      resetDatabase,
       getDbConnectionParameters: async () => getDbConnectionParameters(),
     };
   };

--- a/node-it-docker.js
+++ b/node-it-docker.js
@@ -12,54 +12,79 @@ const docker = new Docker({ socketPath: '/var/run/docker.sock' });
 
 const LOCALHOST = '127.0.0.1';
 const MYSQL_DEFAULT_PORT = '3306';
+const DEFAULT_IT_IMAGE_NAME = '989173062527.dkr.ecr.eu-west-1.amazonaws.com/it-mysql-v2';
+const DEFAULT_IT_CONTAINER_NAME = 'node-it-container-qwerty12345';
+const DEFAULT_CONTAINER_NETWORK_NAME = 'node-it-test-net';
+const DEFAULT_EXTERNAL_PORT = 3806;
 
 async function sleep(timeMs) {
   return new Promise(resolve => setTimeout(resolve, timeMs));
 }
 
-async function connectRunningContainerToNetwork(currentContainerId, network) {
+function createRunId() {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function hasOption(options, key) {
+  return Object.prototype.hasOwnProperty.call(options, key);
+}
+
+function isDynamicHostPort(externalPort) {
+  return externalPort === 0 || externalPort === '0' || externalPort === null;
+}
+
+function createLabels(runId) {
+  return {
+    'com.nursebuddy.integration-test': 'node-it-docker',
+    'com.nursebuddy.integration-test.runner': 'node-it-docker',
+    'com.nursebuddy.integration-test.run-id': runId,
+  };
+}
+
+async function connectRunningContainerToNetwork(currentContainerId, network, logger) {
   if (currentContainerId) {
-    log.info(`Connecting the current container ('${currentContainerId}') to the IT DB network.`);
+    logger.info(`Connecting the current container ('${currentContainerId}') to the IT DB network.`);
     await network.connect({ Container: currentContainerId });
   }
 }
 
-async function disconnectRunningContainerFromNetwork(currentContainerId, network) {
+async function disconnectRunningContainerFromNetwork(currentContainerId, network, logger) {
   if (currentContainerId) {
-    log.info(`Disconnecting the current container ('${currentContainerId}') from the IT DB network.`);
+    logger.info(`Disconnecting the current container ('${currentContainerId}') from the IT DB network.`);
     await network.disconnect({ Container: currentContainerId, Force: true });
   }
 }
 
-async function getOrCreateNetwork(containerNetworkName) {
+async function getOrCreateNetwork(dockerClient, containerNetworkName, labels, logger) {
   let network;
   try {
-    const existingNetworks = await docker.listNetworks();
+    const existingNetworks = await dockerClient.listNetworks();
     const found = existingNetworks.find(n => n.Name === containerNetworkName);
     if (found) {
-      network = docker.getNetwork(found.Id);
+      network = dockerClient.getNetwork(found.Id);
     }
   } catch (err) {
-    log.debug('Failed to list docker networks.', err);
+    logger.debug('Failed to list docker networks.', err);
   }
 
   if (!network) {
-    log.info('No existing network, creating it.');
-    network = await docker.createNetwork({
+    logger.info('No existing network, creating it.');
+    network = await dockerClient.createNetwork({
       Name: containerNetworkName,
       CheckDuplicate: true,
       Attachable: true,
+      Labels: labels,
     });
-    network = docker.getNetwork(network.id);
-    log.info(`Network '${containerNetworkName}' created`);
+    network = dockerClient.getNetwork(network.id);
+    logger.info(`Network '${containerNetworkName}' created`);
   }
 
   return network;
 }
 
-async function connect(externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName) {
+async function connect(mysqlClient, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName) {
   return new Promise((resolve, reject) => {
-    const connection = mysql.createConnection({
+    const connection = mysqlClient.createConnection({
       host: currentContainerId ? itContainerName : LOCALHOST,
       port: currentContainerId ? MYSQL_DEFAULT_PORT : externalPort,
       user: dbUsername,
@@ -72,7 +97,7 @@ async function connect(externalPort, currentContainerId, itContainerName, dbUser
 
       connection.query('SELECT id AS id FROM integration_test_flag LIMIT 1', (err, res) => {
         connection.destroy();
-        if (err || res.length !== 1) {
+        if (err || !res || res.length !== 1) {
           return reject(err || { msg: 'Invalid length' });
         }
         return resolve(true);
@@ -81,86 +106,135 @@ async function connect(externalPort, currentContainerId, itContainerName, dbUser
   });
 }
 
-async function verifyDatabaseConnection(verifyDbConnection, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, stopFn) {
+async function verifyDatabaseConnection(verifyDbConnection, mysqlClient, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, stopFn, logger, sleepFn) {
   let lastError;
   let waitPeriod = 500;
   const start = Date.now();
 
-  if (verifyDbConnection) {
-    for (let i = 0; i < 10; i++) {
-      try {
-        if (await connect(externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName)) {
-          log.info(`DB Connection verified in : ${Date.now() - start} ms.`);
-          return true;
-        }
-      } catch (err) {
-        lastError = err;
-      }
-      await sleep(waitPeriod);
-      waitPeriod += Math.round(waitPeriod / 2);
-    }
-
-    log.warn({ msg: 'DB connection failed:', error: lastError });
-    await stopFn();
-    return false;
+  if (!verifyDbConnection) {
+    return true;
   }
+
+  for (let i = 0; i < 10; i++) {
+    try {
+      if (await connect(mysqlClient, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName)) {
+        logger.info(`DB Connection verified in : ${Date.now() - start} ms.`);
+        return true;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    await sleepFn(waitPeriod);
+    waitPeriod += Math.round(waitPeriod / 2);
+  }
+
+  logger.warn({ msg: 'DB connection failed:', error: lastError });
+  await stopFn();
+  return false;
 }
 
-const NodeItDocker = ({
-  itImageName = '989173062527.dkr.ecr.eu-west-1.amazonaws.com/it-mysql-v2',
-  itContainerName = 'node-it-container-qwerty12345',
-  externalPort = 3806,
-  containerNetworkName = 'node-it-test-net',
-  dataDir = '/var/lib/mysql',
-  currentContainerId = null,
-  verifyDbConnection = true,
-  dbUsername = 'ituser',
-  dbPassword = 'ituser',
-  dbName = 'nursebuddy',
-}) => {
-  currentContainerId = process.env.IT_CONTAINER || currentContainerId || null;
-  itImageName = process.env.IT_IMAGE_NAME || itImageName;
+async function resolveExternalPort(container, externalPort, currentContainerId) {
+  if (currentContainerId) {
+    return MYSQL_DEFAULT_PORT;
+  }
 
-  return {
-    stop: async () => {
+  if (!isDynamicHostPort(externalPort)) {
+    return externalPort;
+  }
+
+  const inspected = await container.inspect();
+  const bindings = inspected
+    && inspected.NetworkSettings
+    && inspected.NetworkSettings.Ports
+    && inspected.NetworkSettings.Ports[`${MYSQL_DEFAULT_PORT}/tcp`];
+
+  if (!bindings || !bindings[0] || !bindings[0].HostPort) {
+    throw new Error(`Failed to resolve dynamic Docker host port for MySQL port ${MYSQL_DEFAULT_PORT}.`);
+  }
+
+  return bindings[0].HostPort;
+}
+
+function createNodeItDocker(dockerClient = docker, mysqlClient = mysql, logger = log, sleepFn = sleep) {
+  return function NodeItDocker(options = {}) {
+    const runId = createRunId();
+    const useDynamicDefaults = options.useDynamicDefaults === true || options.dynamicPort === true;
+    const configuredExternalPort = hasOption(options, 'externalPort')
+      ? options.externalPort
+      : (options.dynamicPort === true ? 0 : DEFAULT_EXTERNAL_PORT);
+
+    const itContainerName = options.itContainerName
+      || (useDynamicDefaults ? `node-it-container-${runId}` : DEFAULT_IT_CONTAINER_NAME);
+    const containerNetworkName = options.containerNetworkName
+      || (useDynamicDefaults ? `node-it-test-net-${runId}` : DEFAULT_CONTAINER_NETWORK_NAME);
+    const dataDir = options.dataDir || '/var/lib/mysql';
+    const verifyDbConnection = hasOption(options, 'verifyDbConnection') ? options.verifyDbConnection : true;
+    const dbUsername = options.dbUsername || 'ituser';
+    const dbPassword = options.dbPassword || 'ituser';
+    const dbName = options.dbName || 'nursebuddy';
+    const labels = createLabels(runId);
+    let currentContainerId = process.env.IT_CONTAINER || options.currentContainerId || null;
+    let itImageName = process.env.IT_IMAGE_NAME || process.env.IT_MYSQL_IMAGE || options.itImageName || DEFAULT_IT_IMAGE_NAME;
+    let resolvedExternalPort = configuredExternalPort;
+
+    function getDbConnectionParameters() {
+      return {
+        host: currentContainerId ? itContainerName : LOCALHOST,
+        port: currentContainerId ? MYSQL_DEFAULT_PORT : resolvedExternalPort,
+        user: dbUsername,
+        password: dbPassword,
+        database: dbName,
+      };
+    }
+
+    async function stop() {
       try {
-        const container = docker.getContainer(itContainerName);
+        const container = dockerClient.getContainer(itContainerName);
         await container.stop();
         await container.remove({ force: true });
-
-        const network = docker.getNetwork(containerNetworkName);
-        if (currentContainerId) {
-          await disconnectRunningContainerFromNetwork(currentContainerId, network);
-        }
-        await network.remove({ force: true });
-        log.info('Container stopped.');
       } catch (err) {
-        log.warn('Failed to stop container or network:', err);
+        logger.warn('Failed to stop or remove container:', err);
       }
-    },
-
-    start: async () => {
-      let container;
-      let network = await getOrCreateNetwork(containerNetworkName);
 
       try {
-        container = docker.getContainer(itContainerName);
-        await container.inspect();
+        const network = dockerClient.getNetwork(containerNetworkName);
+        if (currentContainerId) {
+          await disconnectRunningContainerFromNetwork(currentContainerId, network, logger);
+        }
+        await network.remove({ force: true });
+        logger.info('Container stopped.');
+      } catch (err) {
+        logger.warn('Failed to remove network:', err);
+      }
+    }
+
+    async function start() {
+      let container;
+      let inspected;
+      const network = await getOrCreateNetwork(dockerClient, containerNetworkName, labels, logger);
+
+      try {
+        container = dockerClient.getContainer(itContainerName);
+        inspected = await container.inspect();
       } catch {
-        log.info('Creating container');
-        container = await docker.createContainer({
+        logger.info('Creating container');
+        container = await dockerClient.createContainer({
           Image: itImageName,
           name: itContainerName,
+          Labels: labels,
+          ExposedPorts: {
+            [`${MYSQL_DEFAULT_PORT}/tcp`]: {},
+          },
           HostConfig: {
             PortBindings: {
               [`${MYSQL_DEFAULT_PORT}/tcp`]: [{
                 HostIP: '0.0.0.0',
-                HostPort: `${externalPort}`,
+                HostPort: isDynamicHostPort(configuredExternalPort) ? '' : `${configuredExternalPort}`,
               }],
             },
             Tmpfs: {
               [dataDir]: 'rw,noexec,nosuid,size=600m',
-              '/tmp': 'rw,noexec,nosuid,size=50m'
+              '/tmp': 'rw,noexec,nosuid,size=50m',
             },
           },
           NetworkingConfig: {
@@ -171,55 +245,53 @@ const NodeItDocker = ({
             },
           },
         });
-        container = docker.getContainer(container.id);
-        log.info(`Container '${container.id}' created.`);
+        container = dockerClient.getContainer(container.id);
+        logger.info(`Container '${container.id}' created.`);
       }
 
-      await container.start();
-      await connectRunningContainerToNetwork(currentContainerId, network);
-
-      if (await verifyDatabaseConnection(verifyDbConnection, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, this.stop)) {
-        return {
-          host: currentContainerId ? itContainerName : LOCALHOST,
-          port: currentContainerId ? MYSQL_DEFAULT_PORT : externalPort,
-          user: dbUsername,
-          password: dbPassword,
-          database: dbName,
-        };
-      }
-      return null;
-    },
-
-    restart: async () => {
       try {
-        const container = docker.getContainer(itContainerName);
-        await container.restart();
-        if (await verifyDatabaseConnection(verifyDbConnection, externalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, this.stop)) {
-          return {
-            host: currentContainerId ? itContainerName : LOCALHOST,
-            port: currentContainerId ? MYSQL_DEFAULT_PORT : externalPort,
-            user: dbUsername,
-            password: dbPassword,
-            database: dbName,
-          };
+        if (!inspected || !inspected.State || !inspected.State.Running) {
+          await container.start();
+        }
+
+        await connectRunningContainerToNetwork(currentContainerId, network, logger);
+        resolvedExternalPort = await resolveExternalPort(container, configuredExternalPort, currentContainerId);
+
+        if (await verifyDatabaseConnection(verifyDbConnection, mysqlClient, resolvedExternalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, stop, logger, sleepFn)) {
+          return getDbConnectionParameters();
         }
         return null;
       } catch (err) {
-        log.warn('Restart failed, starting new container.', err);
-        return this.start();
+        logger.warn('Failed to start container:', err);
+        await stop();
+        throw err;
       }
-    },
+    }
 
-    getDbConnectionParameters: async () => {
-      return {
-        host: currentContainerId ? itContainerName : LOCALHOST,
-        port: currentContainerId ? MYSQL_DEFAULT_PORT : externalPort,
-        user: dbUsername,
-        password: dbPassword,
-        database: dbName,
-      };
-    },
+    async function restart() {
+      try {
+        const container = dockerClient.getContainer(itContainerName);
+        await container.restart();
+        resolvedExternalPort = await resolveExternalPort(container, configuredExternalPort, currentContainerId);
+        if (await verifyDatabaseConnection(verifyDbConnection, mysqlClient, resolvedExternalPort, currentContainerId, itContainerName, dbUsername, dbPassword, dbName, stop, logger, sleepFn)) {
+          return getDbConnectionParameters();
+        }
+        return null;
+      } catch (err) {
+        logger.warn('Restart failed, starting new container.', err);
+        await stop();
+        return start();
+      }
+    }
+
+    return {
+      stop,
+      start,
+      restart,
+      getDbConnectionParameters: async () => getDbConnectionParameters(),
+    };
   };
-};
+}
 
-exports.NodeItDocker = NodeItDocker;
+exports.createNodeItDocker = createNodeItDocker;
+exports.NodeItDocker = createNodeItDocker();

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-it-docker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Node Docker IT DB launcher",
   "main": "node-it-docker",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "author": "Nursebuddy",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node Docker IT DB launcher",
   "main": "node-it-docker",
   "scripts": {
+    "smoke:docker": "node scripts/smoke-docker.js",
     "test": "node --test"
   },
   "author": "Nursebuddy",

--- a/scripts/smoke-docker.js
+++ b/scripts/smoke-docker.js
@@ -38,6 +38,13 @@ function queryFlag(connectionParams) {
 
     await queryFlag(db);
 
+    const reset = await nodeItDocker.resetDatabase();
+    if (!reset || !reset.host || !reset.port) {
+      throw new Error('resetDatabase() did not return usable DB parameters');
+    }
+
+    await queryFlag(reset);
+
     const restarted = await nodeItDocker.restart();
     if (!restarted || !restarted.host || !restarted.port) {
       throw new Error('restart() did not return usable DB parameters');

--- a/scripts/smoke-docker.js
+++ b/scripts/smoke-docker.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const mysql = require('mysql');
+const { NodeItDocker } = require('../node-it-docker');
+
+function queryFlag(connectionParams) {
+  return new Promise((resolve, reject) => {
+    const connection = mysql.createConnection(connectionParams);
+
+    connection.connect(err => {
+      if (err) {
+        connection.destroy();
+        return reject(err);
+      }
+
+      connection.query('SELECT id AS id FROM integration_test_flag LIMIT 1', (err, rows) => {
+        connection.destroy();
+        if (err) return reject(err);
+        if (!rows || rows.length !== 1) {
+          return reject(new Error('integration_test_flag smoke query returned no row'));
+        }
+        return resolve();
+      });
+    });
+  });
+}
+
+(async function main() {
+  const nodeItDocker = NodeItDocker({
+    dynamicPort: true,
+  });
+
+  try {
+    const db = await nodeItDocker.start();
+    if (!db || !db.host || !db.port) {
+      throw new Error('start() did not return usable DB parameters');
+    }
+
+    await queryFlag(db);
+
+    const restarted = await nodeItDocker.restart();
+    if (!restarted || !restarted.host || !restarted.port) {
+      throw new Error('restart() did not return usable DB parameters');
+    }
+
+    await queryFlag(restarted);
+  } finally {
+    await nodeItDocker.stop();
+  }
+})();

--- a/test/node-it-docker.test.js
+++ b/test/node-it-docker.test.js
@@ -52,6 +52,7 @@ function createDockerStub() {
         calls.push(['network.remove', name, opts]);
         this.removed = true;
         networks.delete(name);
+        networks.delete(id);
       },
     };
   }
@@ -73,6 +74,7 @@ function createDockerStub() {
       started: false,
       stopped: false,
       removed: false,
+      stopError: null,
       restartError: null,
       async inspect() {
         calls.push(['container.inspect', name]);
@@ -99,6 +101,9 @@ function createDockerStub() {
       },
       async stop() {
         calls.push(['container.stop', name]);
+        if (this.stopError) {
+          throw this.stopError;
+        }
         this.stopped = true;
         this.started = false;
       },
@@ -122,6 +127,7 @@ function createDockerStub() {
     calls,
     containers,
     networks,
+    createContainerError: null,
     async listNetworks() {
       calls.push(['listNetworks']);
       return Array.from(networks.values()).map(network => ({ Id: network.id, Name: network.name }));
@@ -142,6 +148,9 @@ function createDockerStub() {
     },
     async createContainer(options) {
       calls.push(['createContainer', options]);
+      if (this.createContainerError) {
+        throw this.createContainerError;
+      }
       const container = makeContainer(options);
       containers.set(options.name, container);
       containers.set(container.id, container);
@@ -308,6 +317,37 @@ test('uses IT_IMAGE_NAME before IT_MYSQL_IMAGE and constructor image', async () 
   }
 });
 
+test('uses IT_MYSQL_IMAGE when legacy IT_IMAGE_NAME is not set', async () => {
+  const originalImageName = process.env.IT_IMAGE_NAME;
+  const originalMysqlImage = process.env.IT_MYSQL_IMAGE;
+  delete process.env.IT_IMAGE_NAME;
+  process.env.IT_MYSQL_IMAGE = 'env-mysql-image';
+
+  try {
+    const { docker, nodeItDocker } = createSubject({
+      itImageName: 'constructor-image',
+      verifyDbConnection: false,
+    });
+
+    await nodeItDocker.start();
+    const createContainerCall = docker.calls.find(([name]) => name === 'createContainer');
+
+    assert.equal(createContainerCall[1].Image, 'env-mysql-image');
+  } finally {
+    if (originalImageName === undefined) {
+      delete process.env.IT_IMAGE_NAME;
+    } else {
+      process.env.IT_IMAGE_NAME = originalImageName;
+    }
+
+    if (originalMysqlImage === undefined) {
+      delete process.env.IT_MYSQL_IMAGE;
+    } else {
+      process.env.IT_MYSQL_IMAGE = originalMysqlImage;
+    }
+  }
+});
+
 test('falls back to start when restart fails without using method this binding', async () => {
   const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
 
@@ -324,6 +364,62 @@ test('falls back to start when restart fails without using method this binding',
   );
 });
 
+test('successful restart returns stable connection parameters', async () => {
+  const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
+
+  const startParams = await nodeItDocker.start();
+  const firstRestartParams = await nodeItDocker.restart();
+  const secondRestartParams = await nodeItDocker.restart();
+
+  assert.deepEqual(firstRestartParams, startParams);
+  assert.deepEqual(secondRestartParams, startParams);
+  assert.equal(docker.calls.filter(([name]) => name === 'container.restart').length, 2);
+});
+
+test('start is idempotent when the container is already running', async () => {
+  const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
+
+  const first = await nodeItDocker.start();
+  const second = await nodeItDocker.start();
+
+  assert.deepEqual(second, first);
+  assert.equal(docker.calls.filter(([name]) => name === 'createContainer').length, 1);
+  assert.equal(docker.calls.filter(([name]) => name === 'container.start').length, 1);
+});
+
+test('stop removes the container even when stop fails and can be repeated', async () => {
+  const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
+
+  await nodeItDocker.start();
+  const container = docker.containers.get('node-it-container-qwerty12345');
+  container.stopError = new Error('already stopped');
+
+  await nodeItDocker.stop();
+  await nodeItDocker.stop();
+
+  assert.ok(docker.calls.some(([name]) => name === 'container.remove'));
+  assert.ok(docker.calls.some(([name]) => name === 'network.remove'));
+});
+
+test('two dynamic helpers use distinct container, network, and host port values', async () => {
+  const docker = createDockerStub();
+  const mysql = createMysqlStub();
+  const NodeItDocker = createNodeItDocker(docker, mysql, createLogger(), async () => {});
+
+  const first = NodeItDocker({ dynamicPort: true, verifyDbConnection: false });
+  const second = NodeItDocker({ dynamicPort: true, verifyDbConnection: false });
+
+  const firstParams = await first.start();
+  const secondParams = await second.start();
+
+  const createContainerCalls = docker.calls.filter(([name]) => name === 'createContainer');
+  const createNetworkCalls = docker.calls.filter(([name]) => name === 'createNetwork');
+
+  assert.notEqual(createContainerCalls[0][1].name, createContainerCalls[1][1].name);
+  assert.notEqual(createNetworkCalls[0][1].Name, createNetworkCalls[1][1].Name);
+  assert.notEqual(firstParams.port, secondParams.port);
+});
+
 test('cleans up and returns null when database verification fails', async () => {
   const docker = createDockerStub();
   const mysql = createMysqlStub({ failConnect: true });
@@ -334,5 +430,17 @@ test('cleans up and returns null when database verification fails', async () => 
 
   assert.equal(params, null);
   assert.ok(docker.calls.some(([name]) => name === 'container.remove'));
+  assert.ok(docker.calls.some(([name]) => name === 'network.remove'));
+});
+
+test('cleans up network when container creation fails', async () => {
+  const docker = createDockerStub();
+  docker.createContainerError = new Error('create failed');
+  const mysql = createMysqlStub();
+  const NodeItDocker = createNodeItDocker(docker, mysql, createLogger(), async () => {});
+  const nodeItDocker = NodeItDocker({ dynamicPort: true, verifyDbConnection: false });
+
+  await assert.rejects(() => nodeItDocker.start(), /create failed/);
+
   assert.ok(docker.calls.some(([name]) => name === 'network.remove'));
 });

--- a/test/node-it-docker.test.js
+++ b/test/node-it-docker.test.js
@@ -15,17 +15,25 @@ function createLogger() {
 
 function createMysqlStub({ failConnect = false } = {}) {
   const connections = [];
-  return {
+  const mysqlStub = {
     connections,
-    createConnection: config => {
+    failConnectCount: failConnect ? Number.POSITIVE_INFINITY : 0,
+    createConnection(config) {
       connections.push(config);
       return {
-        connect: cb => cb(failConnect ? new Error('connect failed') : null),
+        connect: (cb) => {
+          if (mysqlStub.failConnectCount > 0) {
+            mysqlStub.failConnectCount -= 1;
+            return cb(new Error('connect failed'));
+          }
+          return cb(null);
+        },
         query: (sql, cb) => cb(null, [{ id: 1 }]),
         destroy: () => {},
       };
     },
   };
+  return mysqlStub;
 }
 
 function createDockerStub() {
@@ -396,6 +404,24 @@ test('falls back to start when restart fails without using method this binding',
   assert.deepEqual(
     docker.calls.filter(([name]) => ['container.restart', 'container.start'].includes(name)).map(([name]) => name),
     ['container.start', 'container.restart', 'container.start'],
+  );
+});
+
+test('falls back to start when restart verification fails', async () => {
+  const { docker, mysql, nodeItDocker } = createSubject({ dynamicPort: true });
+
+  const startParams = await nodeItDocker.start();
+  const originalContainer = Array.from(docker.containers.values())
+    .find(item => item.createOptions && item.createOptions.name.startsWith('node-it-container-'));
+
+  mysql.failConnectCount = 10;
+  const restartParams = await nodeItDocker.restart();
+
+  assert.notEqual(restartParams.port, startParams.port);
+  assert.equal(originalContainer.removed, true);
+  assert.deepEqual(
+    docker.calls.filter(([name]) => ['container.restart', 'container.stop', 'container.remove', 'container.start'].includes(name)).map(([name]) => name),
+    ['container.start', 'container.restart', 'container.stop', 'container.remove', 'container.start'],
   );
 });
 

--- a/test/node-it-docker.test.js
+++ b/test/node-it-docker.test.js
@@ -146,7 +146,10 @@ function createDockerStub() {
         return {
           async start() {
             calls.push(['exec.start', name, options.Cmd]);
-            return Readable.from([result.stdout || '', result.stderr || '']);
+            const stream = Readable.from([]);
+            stream.stdoutData = result.stdout || '';
+            stream.stderrData = result.stderr || '';
+            return stream;
           },
           async inspect() {
             calls.push(['exec.inspect', name, options.Cmd]);
@@ -162,6 +165,17 @@ function createDockerStub() {
     containers,
     networks,
     createContainerError: null,
+    modem: {
+      demuxStream(stream, stdout, stderr) {
+        if (stream.stdoutData) {
+          stdout.write(stream.stdoutData);
+        }
+        if (stream.stderrData) {
+          stderr.write(stream.stderrData);
+        }
+        stream.resume();
+      },
+    },
     async listNetworks() {
       calls.push(['listNetworks']);
       return Array.from(networks.values()).map(network => ({ Id: network.id, Name: network.name }));
@@ -437,7 +451,7 @@ test('falls back to start when restart verification fails', async () => {
   const originalContainer = Array.from(docker.containers.values())
     .find(item => item.createOptions && item.createOptions.name.startsWith('node-it-container-'));
 
-  mysql.failConnectCount = 10;
+  mysql.failConnectCount = 120;
   const restartParams = await nodeItDocker.restart();
 
   assert.notEqual(restartParams.port, startParams.port);
@@ -458,6 +472,24 @@ test('successful restart returns stable connection parameters', async () => {
   assert.deepEqual(firstRestartParams, startParams);
   assert.deepEqual(secondRestartParams, startParams);
   assert.equal(docker.calls.filter(([name]) => name === 'container.restart').length, 2);
+});
+
+test('database readiness polling retries quickly while MySQL starts', async () => {
+  const mysql = createMysqlStub();
+  const sleepPeriods = [];
+  mysql.failConnectCount = 3;
+
+  const { nodeItDocker } = createSubject({}, {
+    mysql,
+    sleep: async (timeMs) => {
+      sleepPeriods.push(timeMs);
+    },
+  });
+
+  const params = await nodeItDocker.start();
+
+  assert.ok(params);
+  assert.deepEqual(sleepPeriods, [100, 100, 100]);
 });
 
 test('resetDatabase uses the SQL reset script and returns stable connection parameters', async () => {

--- a/test/node-it-docker.test.js
+++ b/test/node-it-docker.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('node:assert/strict');
+const { Readable } = require('node:stream');
 const test = require('node:test');
 
 const { createNodeItDocker } = require('../node-it-docker');
@@ -91,6 +92,7 @@ function createDockerStub() {
       removed: false,
       stopError: null,
       restartError: null,
+      execResults: [],
       async inspect() {
         calls.push(['container.inspect', name]);
         if (this.removed) {
@@ -134,6 +136,23 @@ function createDockerStub() {
           throw this.restartError;
         }
         this.started = true;
+      },
+      async exec(options) {
+        calls.push(['container.exec', name, options]);
+        const result = this.execResults.length > 0
+          ? this.execResults.shift()
+          : { exitCode: 0, stdout: '' };
+
+        return {
+          async start() {
+            calls.push(['exec.start', name, options.Cmd]);
+            return Readable.from([result.stdout || '', result.stderr || '']);
+          },
+          async inspect() {
+            calls.push(['exec.inspect', name, options.Cmd]);
+            return { ExitCode: result.exitCode || 0 };
+          },
+        };
       },
     };
   }
@@ -208,6 +227,10 @@ function createDockerStub() {
         },
         async restart() {
           calls.push(['container.restart', nameOrId]);
+          throw new Error('not found');
+        },
+        async exec() {
+          calls.push(['container.exec', nameOrId]);
           throw new Error('not found');
         },
       };
@@ -435,6 +458,34 @@ test('successful restart returns stable connection parameters', async () => {
   assert.deepEqual(firstRestartParams, startParams);
   assert.deepEqual(secondRestartParams, startParams);
   assert.equal(docker.calls.filter(([name]) => name === 'container.restart').length, 2);
+});
+
+test('resetDatabase uses the SQL reset script and returns stable connection parameters', async () => {
+  const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
+
+  const startParams = await nodeItDocker.start();
+  const resetParams = await nodeItDocker.resetDatabase();
+
+  assert.deepEqual(resetParams, startParams);
+  assert.deepEqual(
+    docker.calls.find(([name]) => name === 'container.exec')[2].Cmd,
+    ['/usr/local/bin/reset-nursebuddy-db', 'nursebuddy'],
+  );
+  assert.equal(docker.calls.filter(([name]) => name === 'container.restart').length, 0);
+});
+
+test('resetDatabase falls back to restart when the SQL reset script is unavailable', async () => {
+  const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
+
+  const startParams = await nodeItDocker.start();
+  const container = docker.containers.get('node-it-container-qwerty12345');
+  container.execResults.push({ exitCode: 127, stderr: 'reset-nursebuddy-db: not found' });
+
+  const resetParams = await nodeItDocker.resetDatabase();
+
+  assert.deepEqual(resetParams, startParams);
+  assert.equal(docker.calls.filter(([name]) => name === 'container.exec').length, 1);
+  assert.equal(docker.calls.filter(([name]) => name === 'container.restart').length, 1);
 });
 
 test('start is idempotent when the container is already running', async () => {

--- a/test/node-it-docker.test.js
+++ b/test/node-it-docker.test.js
@@ -42,10 +42,17 @@ function createDockerStub() {
       removed: false,
       connected: [],
       disconnected: [],
+      disconnectError: null,
       async connect(opts) {
+        if (this.connected.some(item => item.Container === opts.Container)) {
+          throw new Error(`endpoint with name ${opts.Container} already exists in network ${name}`);
+        }
         this.connected.push(opts);
       },
       async disconnect(opts) {
+        if (this.disconnectError) {
+          throw this.disconnectError;
+        }
         this.disconnected.push(opts);
       },
       async remove(opts) {
@@ -144,7 +151,20 @@ function createDockerStub() {
       const network = networks.get(nameOrId);
       if (network) return network;
 
-      return makeNetwork(nameOrId, nameOrId);
+      return {
+        async connect() {
+          calls.push(['network.connect', nameOrId]);
+          throw new Error('network not found');
+        },
+        async disconnect() {
+          calls.push(['network.disconnect', nameOrId]);
+          throw new Error('network not found');
+        },
+        async remove(opts) {
+          calls.push(['network.remove', nameOrId, opts]);
+          throw new Error('network not found');
+        },
+      };
     },
     async createContainer(options) {
       calls.push(['createContainer', options]);
@@ -286,6 +306,21 @@ test('returns docker-network connection parameters when running inside a contain
   assert.deepEqual(network.connected, [{ Container: 'current-test-container' }]);
 });
 
+test('start is idempotent when the current container is already connected to the network', async () => {
+  const { docker, nodeItDocker } = createSubject({
+    currentContainerId: 'current-test-container',
+    itContainerName: 'mysql-service',
+    verifyDbConnection: false,
+  });
+
+  const first = await nodeItDocker.start();
+  const second = await nodeItDocker.start();
+  const network = Array.from(docker.networks.values()).find(item => item.name === 'node-it-test-net');
+
+  assert.deepEqual(second, first);
+  assert.deepEqual(network.connected, [{ Container: 'current-test-container' }]);
+});
+
 test('uses IT_IMAGE_NAME before IT_MYSQL_IMAGE and constructor image', async () => {
   const originalImageName = process.env.IT_IMAGE_NAME;
   const originalMysqlImage = process.env.IT_MYSQL_IMAGE;
@@ -398,6 +433,22 @@ test('stop removes the container even when stop fails and can be repeated', asyn
   await nodeItDocker.stop();
 
   assert.ok(docker.calls.some(([name]) => name === 'container.remove'));
+  assert.ok(docker.calls.some(([name]) => name === 'network.remove'));
+});
+
+test('stop removes the network even when disconnecting the current container fails', async () => {
+  const { docker, nodeItDocker } = createSubject({
+    currentContainerId: 'current-test-container',
+    verifyDbConnection: false,
+  });
+
+  await nodeItDocker.start();
+  const network = Array.from(docker.networks.values()).find(item => item.name === 'node-it-test-net');
+  network.disconnectError = new Error('endpoint not found');
+
+  await nodeItDocker.stop();
+
+  assert.ok(network.removed);
   assert.ok(docker.calls.some(([name]) => name === 'network.remove'));
 });
 

--- a/test/node-it-docker.test.js
+++ b/test/node-it-docker.test.js
@@ -1,0 +1,338 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { createNodeItDocker } = require('../node-it-docker');
+
+function createLogger() {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+  };
+}
+
+function createMysqlStub({ failConnect = false } = {}) {
+  const connections = [];
+  return {
+    connections,
+    createConnection: config => {
+      connections.push(config);
+      return {
+        connect: cb => cb(failConnect ? new Error('connect failed') : null),
+        query: (sql, cb) => cb(null, [{ id: 1 }]),
+        destroy: () => {},
+      };
+    },
+  };
+}
+
+function createDockerStub() {
+  const calls = [];
+  const containers = new Map();
+  const networks = new Map();
+  let containerSeq = 0;
+  let hostPortSeq = 49152;
+
+  function makeNetwork(name, id = name) {
+    return {
+      id,
+      name,
+      removed: false,
+      connected: [],
+      disconnected: [],
+      async connect(opts) {
+        this.connected.push(opts);
+      },
+      async disconnect(opts) {
+        this.disconnected.push(opts);
+      },
+      async remove(opts) {
+        calls.push(['network.remove', name, opts]);
+        this.removed = true;
+        networks.delete(name);
+      },
+    };
+  }
+
+  function makeContainer(createOptions) {
+    const id = createOptions.id || `container-${++containerSeq}`;
+    const name = createOptions.name || id;
+    const binding = createOptions.HostConfig
+      && createOptions.HostConfig.PortBindings
+      && createOptions.HostConfig.PortBindings['3306/tcp']
+      && createOptions.HostConfig.PortBindings['3306/tcp'][0];
+    const requestedPort = binding && binding.HostPort;
+    const hostPort = requestedPort || `${hostPortSeq++}`;
+
+    return {
+      id,
+      name,
+      createOptions,
+      started: false,
+      stopped: false,
+      removed: false,
+      restartError: null,
+      async inspect() {
+        calls.push(['container.inspect', name]);
+        if (this.removed) {
+          throw new Error('not found');
+        }
+        return {
+          Id: id,
+          State: {
+            Running: this.started,
+          },
+          NetworkSettings: {
+            Ports: {
+              '3306/tcp': [{
+                HostPort: hostPort,
+              }],
+            },
+          },
+        };
+      },
+      async start() {
+        calls.push(['container.start', name]);
+        this.started = true;
+      },
+      async stop() {
+        calls.push(['container.stop', name]);
+        this.stopped = true;
+        this.started = false;
+      },
+      async remove(opts) {
+        calls.push(['container.remove', name, opts]);
+        this.removed = true;
+        containers.delete(name);
+        containers.delete(id);
+      },
+      async restart() {
+        calls.push(['container.restart', name]);
+        if (this.restartError) {
+          throw this.restartError;
+        }
+        this.started = true;
+      },
+    };
+  }
+
+  const docker = {
+    calls,
+    containers,
+    networks,
+    async listNetworks() {
+      calls.push(['listNetworks']);
+      return Array.from(networks.values()).map(network => ({ Id: network.id, Name: network.name }));
+    },
+    async createNetwork(options) {
+      calls.push(['createNetwork', options]);
+      const network = makeNetwork(options.Name, `network-${options.Name}`);
+      networks.set(options.Name, network);
+      networks.set(network.id, network);
+      return { id: network.id };
+    },
+    getNetwork(nameOrId) {
+      calls.push(['getNetwork', nameOrId]);
+      const network = networks.get(nameOrId);
+      if (network) return network;
+
+      return makeNetwork(nameOrId, nameOrId);
+    },
+    async createContainer(options) {
+      calls.push(['createContainer', options]);
+      const container = makeContainer(options);
+      containers.set(options.name, container);
+      containers.set(container.id, container);
+      return { id: container.id };
+    },
+    getContainer(nameOrId) {
+      calls.push(['getContainer', nameOrId]);
+      const existing = containers.get(nameOrId);
+      if (existing) return existing;
+
+      return {
+        async inspect() {
+          calls.push(['container.inspect', nameOrId]);
+          throw new Error('not found');
+        },
+        async start() {
+          calls.push(['container.start', nameOrId]);
+          throw new Error('not found');
+        },
+        async stop() {
+          calls.push(['container.stop', nameOrId]);
+          throw new Error('not found');
+        },
+        async remove(opts) {
+          calls.push(['container.remove', nameOrId, opts]);
+          throw new Error('not found');
+        },
+        async restart() {
+          calls.push(['container.restart', nameOrId]);
+          throw new Error('not found');
+        },
+      };
+    },
+  };
+
+  return docker;
+}
+
+function createSubject(options = {}, stubs = {}) {
+  const docker = stubs.docker || createDockerStub();
+  const mysql = stubs.mysql || createMysqlStub();
+  const sleep = stubs.sleep || (async () => {});
+  const NodeItDocker = createNodeItDocker(docker, mysql, createLogger(), sleep);
+  return {
+    docker,
+    mysql,
+    nodeItDocker: NodeItDocker(options),
+  };
+}
+
+test('keeps legacy defaults without opt-in dynamic mode', async () => {
+  const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
+
+  const params = await nodeItDocker.start();
+  const createContainerCall = docker.calls.find(([name]) => name === 'createContainer');
+
+  assert.equal(createContainerCall[1].Image, '989173062527.dkr.ecr.eu-west-1.amazonaws.com/it-mysql-v2');
+  assert.equal(createContainerCall[1].name, 'node-it-container-qwerty12345');
+  assert.equal(createContainerCall[1].HostConfig.PortBindings['3306/tcp'][0].HostPort, '3806');
+  assert.deepEqual(params, {
+    host: '127.0.0.1',
+    port: 3806,
+    user: 'ituser',
+    password: 'ituser',
+    database: 'nursebuddy',
+  });
+});
+
+test('supports explicit legacy container, network, port, and db options', async () => {
+  const { docker, nodeItDocker } = createSubject({
+    itImageName: 'custom-image',
+    itContainerName: 'custom-container',
+    containerNetworkName: 'custom-network',
+    externalPort: 3810,
+    verifyDbConnection: false,
+    dbUsername: 'user',
+    dbPassword: 'pass',
+    dbName: 'db',
+  });
+
+  const params = await nodeItDocker.start();
+  const createContainerCall = docker.calls.find(([name]) => name === 'createContainer');
+  const createNetworkCall = docker.calls.find(([name]) => name === 'createNetwork');
+
+  assert.equal(createContainerCall[1].Image, 'custom-image');
+  assert.equal(createContainerCall[1].name, 'custom-container');
+  assert.equal(createNetworkCall[1].Name, 'custom-network');
+  assert.equal(createContainerCall[1].HostConfig.PortBindings['3306/tcp'][0].HostPort, '3810');
+  assert.deepEqual(params, {
+    host: '127.0.0.1',
+    port: 3810,
+    user: 'user',
+    password: 'pass',
+    database: 'db',
+  });
+});
+
+test('uses dynamic port and unique names when dynamic mode is enabled', async () => {
+  const { docker, nodeItDocker } = createSubject({
+    dynamicPort: true,
+    verifyDbConnection: false,
+  });
+
+  const params = await nodeItDocker.start();
+  const createContainerCall = docker.calls.find(([name]) => name === 'createContainer');
+  const createNetworkCall = docker.calls.find(([name]) => name === 'createNetwork');
+
+  assert.match(createContainerCall[1].name, /^node-it-container-/);
+  assert.match(createNetworkCall[1].Name, /^node-it-test-net-/);
+  assert.equal(createContainerCall[1].HostConfig.PortBindings['3306/tcp'][0].HostPort, '');
+  assert.equal(params.host, '127.0.0.1');
+  assert.equal(params.port, '49152');
+  assert.equal(createContainerCall[1].Labels['com.nursebuddy.integration-test'], 'node-it-docker');
+});
+
+test('returns docker-network connection parameters when running inside a container', async () => {
+  const { docker, nodeItDocker } = createSubject({
+    currentContainerId: 'current-test-container',
+    itContainerName: 'mysql-service',
+    verifyDbConnection: false,
+  });
+
+  const params = await nodeItDocker.start();
+  const network = Array.from(docker.networks.values()).find(item => item.name === 'node-it-test-net');
+
+  assert.deepEqual(params, {
+    host: 'mysql-service',
+    port: '3306',
+    user: 'ituser',
+    password: 'ituser',
+    database: 'nursebuddy',
+  });
+  assert.deepEqual(network.connected, [{ Container: 'current-test-container' }]);
+});
+
+test('uses IT_IMAGE_NAME before IT_MYSQL_IMAGE and constructor image', async () => {
+  const originalImageName = process.env.IT_IMAGE_NAME;
+  const originalMysqlImage = process.env.IT_MYSQL_IMAGE;
+  process.env.IT_IMAGE_NAME = 'env-image-name';
+  process.env.IT_MYSQL_IMAGE = 'env-mysql-image';
+
+  try {
+    const { docker, nodeItDocker } = createSubject({
+      itImageName: 'constructor-image',
+      verifyDbConnection: false,
+    });
+
+    await nodeItDocker.start();
+    const createContainerCall = docker.calls.find(([name]) => name === 'createContainer');
+
+    assert.equal(createContainerCall[1].Image, 'env-image-name');
+  } finally {
+    if (originalImageName === undefined) {
+      delete process.env.IT_IMAGE_NAME;
+    } else {
+      process.env.IT_IMAGE_NAME = originalImageName;
+    }
+
+    if (originalMysqlImage === undefined) {
+      delete process.env.IT_MYSQL_IMAGE;
+    } else {
+      process.env.IT_MYSQL_IMAGE = originalMysqlImage;
+    }
+  }
+});
+
+test('falls back to start when restart fails without using method this binding', async () => {
+  const { docker, nodeItDocker } = createSubject({ verifyDbConnection: false });
+
+  await nodeItDocker.start();
+  const container = docker.containers.get('node-it-container-qwerty12345');
+  container.restartError = new Error('restart failed');
+
+  const params = await nodeItDocker.restart();
+
+  assert.equal(params.port, 3806);
+  assert.deepEqual(
+    docker.calls.filter(([name]) => ['container.restart', 'container.start'].includes(name)).map(([name]) => name),
+    ['container.start', 'container.restart', 'container.start'],
+  );
+});
+
+test('cleans up and returns null when database verification fails', async () => {
+  const docker = createDockerStub();
+  const mysql = createMysqlStub({ failConnect: true });
+  const NodeItDocker = createNodeItDocker(docker, mysql, createLogger(), async () => {});
+  const nodeItDocker = NodeItDocker({});
+
+  const params = await nodeItDocker.start();
+
+  assert.equal(params, null);
+  assert.ok(docker.calls.some(([name]) => name === 'container.remove'));
+  assert.ok(docker.calls.some(([name]) => name === 'network.remove'));
+});


### PR DESCRIPTION
## Summary

- Keep legacy `node-it-docker` defaults while adding opt-in dynamic port/container/network behavior for CI-safe integration tests.
- Fix fragile lifecycle paths around restart fallback, idempotent start/stop, cleanup after failures, and image override handling.
- Add unit coverage plus an optional real Docker smoke command for release validation.

## Jira

- NB-9161: https://nursebuddy.atlassian.net/browse/NB-9161

## Implementation notes

- `dynamicPort: true` enables Docker-assigned host ports and unique default container/network names for updated services.
- `IT_MYSQL_IMAGE` is accepted as a workflow-facing image alias while preserving existing `IT_IMAGE_NAME` precedence.
- Legacy no-option behavior remains compatible for existing consumers.

## Test coverage

- Added `node --test` coverage for legacy defaults, dynamic mode, explicit options, env image precedence, restart fallback, repeated lifecycle calls, and cleanup failures.
- Added `npm run smoke:docker` for real Docker/MySQL release smoke validation.
